### PR TITLE
fix: handle window.electronLogger not defined on web browser

### DIFF
--- a/electron-app/src/renderer/logger/browserLogger.ts
+++ b/electron-app/src/renderer/logger/browserLogger.ts
@@ -1,7 +1,10 @@
 declare namespace window {
-  const electronLogger: typeof import('electron-log')['functions']
+  const electronLogger: typeof import('electron-log')['functions'] | undefined
 }
 
-const { electronLogger: browserLogger } = window
+const { electronLogger } = window
+
+// in the dev-mode browser, preload.js not kicked in so electronLogger is undefined
+const browserLogger = electronLogger ?? console
 
 export default browserLogger


### PR DESCRIPTION
electronLogger 는 preload.js 에서 로드 후 넘겨주는데요, 웹 브라우저로 접속할 경우 이것이 존재하지 않습니다.
이 때문에 크롬 디버깅이 불가능해졌는데요, 이를 해결합니다.