### PR TITLE
feature: add event

### DIFF
--- a/electron-app/src/renderer/event/decorator.ts
+++ b/electron-app/src/renderer/event/decorator.ts
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable func-names */
+import { reaction } from 'mobx'
+import EventStore from './eventStore'
+import { IDisposable } from '../types/disposable'
+
+type Prototype = any
+const DisposerSymbol = Symbol('array contains event listen disposer methods')
+
+function registerDisposables(target: any, disposer: Disposer) {
+  const cbs: Disposer[] = target[DisposerSymbol] ?? []
+  target[DisposerSymbol] = cbs
+
+  cbs.push(disposer)
+}
+
+type EventListener<EventArgs> = (e: EventArgs) => void
+
+type EventListenerPropertyDescriptor<EventArgs> = TypedPropertyDescriptor<EventListener<EventArgs>>
+type Disposer = {
+  propertyKey: string
+  disposer: ReturnType<typeof reaction>
+}
+
+export function listen<T>(eventStore: EventStore<T>) {
+  return function (target: Prototype, propertyKey: string, descriptor: EventListenerPropertyDescriptor<T>) {
+    const disposer = reaction(
+      () => eventStore._value,
+      (arg) => {
+        if (arg) {
+          descriptor.value?.(arg)
+        }
+      }
+    )
+
+    registerDisposables(target, { propertyKey, disposer })
+  }
+}
+
+export function listener<T extends { new (...args: any[]): IDisposable }>(Base: T) {
+  return class extends Base {
+    dispose() {
+      this.disposeListeners()
+      super.dispose()
+    }
+
+    disposeListeners() {
+      const disposers: Disposer[] = (this as any)[DisposerSymbol]
+
+      for (const { disposer } of disposers) {
+        disposer()
+      }
+    }
+  }
+}

--- a/electron-app/src/renderer/event/eventStore.ts
+++ b/electron-app/src/renderer/event/eventStore.ts
@@ -1,0 +1,15 @@
+import { action, makeAutoObservable, makeObservable, observable } from 'mobx'
+
+export default class EventStore<T> {
+  @observable
+  _value?: T = undefined // must provide "undefined" or it won't work
+
+  constructor() {
+    makeObservable(this)
+  }
+
+  @action
+  emit(value: T): void {
+    this._value = value
+  }
+}

--- a/electron-app/src/renderer/types/disposable.ts
+++ b/electron-app/src/renderer/types/disposable.ts
@@ -1,0 +1,9 @@
+/* eslint-disable class-methods-use-this */
+
+export interface IDisposable {
+  dispose(): void
+}
+
+export class Disposable implements IDisposable {
+  dispose(): void {}
+}


### PR DESCRIPTION
## Changes
- introduce `IDisposable`, `Disposable` classes
- add mobx-based event, eventStore with decorator

## Example
```ts
@injectable()
class EventEmittingClass {
    readonly event = new EventStore<Error>()
}

@injectable()
class EventListeningClass extends Disposable { // must extends Disposable, or implements IDisposable
    constructor(private readonly eventEmitter: EventEmittingClass) {}

    @listen(this.eventEmitter)
    onEventEmitted(err: Error) {
        // do something...
    }
}
```

## NOTE
- interoperability with `@action` is not clear yet. might need to use `runInAction(() => void)`