### PR TITLE
feature: cluster metadata use fallback region data

### DIFF
--- a/backend/pkg/service/cluster_metadata_service/aws.go
+++ b/backend/pkg/service/cluster_metadata_service/aws.go
@@ -104,6 +104,10 @@ func (r *AwsResolver) listEks(region string) ([]*protos.ClusterMetadata, error) 
 		}
 		meta.ClusterTags = clusterOut.Cluster.Tags
 
+		if _, ok := meta.ClusterTags[types.KnownClusterTag_ClusterRegion.String()]; !ok {
+			meta.ClusterTags[types.KnownClusterTag_ClusterRegion.String()] = region
+		}
+
 		clusters = append(clusters, meta)
 	}
 	return clusters, nil

--- a/backend/pkg/service/cluster_metadata_service/tencent.go
+++ b/backend/pkg/service/cluster_metadata_service/tencent.go
@@ -116,6 +116,11 @@ func (r *TencentResolver) listTke(region string) ([]*protos.ClusterMetadata, err
 				meta.ClusterTags[*tag.Key] = *tag.Value
 			}
 		}
+
+		if _, ok := meta.ClusterTags[types.KnownClusterTag_ClusterRegion.String()]; !ok {
+			meta.ClusterTags[types.KnownClusterTag_ClusterRegion.String()] = region
+		}
+
 		clusters = append(clusters, meta)
 	}
 	return clusters, nil


### PR DESCRIPTION
## Changes
- use region data obtained from querying clusters as `ClusterRegion` tag if it's not already exists