### PR TITLE
feature: grpc timeout, error handling on backend panic

### DIFF
--- a/electron-app/src/renderer/pages/clusterManagement/page.tsx
+++ b/electron-app/src/renderer/pages/clusterManagement/page.tsx
@@ -18,7 +18,7 @@ export default observer(function ClusterManagement() {
 
   // invoke on mount
   useEffect(() => {
-    clusterMetadataStore.fetchMetadata()
+    clusterMetadataStore.fetchMetadata(true)
   }, [clusterMetadataStore])
 
   return (

--- a/electron-app/src/renderer/repositories/clusterRepository.ts
+++ b/electron-app/src/renderer/repositories/clusterRepository.ts
@@ -1,15 +1,23 @@
-import { injectable, singleton } from 'tsyringe'
+import { singleton } from 'tsyringe'
 import { KubeconfigClient } from '../protos/Kubeconfig_serviceServiceClientPb'
 import { GetAvailableClustersRes, RegisterClusterReq } from '../protos/kubeconfig_service_pb'
 import { CommonReq, CommonRes } from '../protos/common_pb'
 import { getDefaultMetadata } from './grpcMetadata'
+import { createErrorResponse } from './error'
 
 @singleton()
 export default class ClusterRepository {
   constructor(private readonly client: KubeconfigClient) {}
 
   async GetAvailableClusters(): Promise<GetAvailableClustersRes> {
-    return this.client.getAvailableClusters(new CommonReq(), getDefaultMetadata())
+    try {
+      return await this.client.getAvailableClusters(new CommonReq(), getDefaultMetadata())
+    } catch (e) {
+      const res = new GetAvailableClustersRes()
+      res.setCommonres(createErrorResponse(e))
+
+      return res
+    }
   }
 
   async RegisterCluster(clusterName: string, accountId: string): Promise<CommonRes> {
@@ -18,10 +26,18 @@ export default class ClusterRepository {
     req.setClustername(clusterName)
     req.setAccountid(accountId)
 
-    return this.client.registerCluster(req, getDefaultMetadata())
+    try {
+      return await this.client.registerCluster(req, getDefaultMetadata())
+    } catch (e) {
+      return createErrorResponse(e)
+    }
   }
 
   async SyncAvailableClusters(): Promise<CommonRes> {
-    return this.client.syncAvailableClusters(new CommonReq(), getDefaultMetadata())
+    try {
+      return await this.client.syncAvailableClusters(new CommonReq(), getDefaultMetadata())
+    } catch (e) {
+      return createErrorResponse(e)
+    }
   }
 }

--- a/electron-app/src/renderer/repositories/clusterRepository.ts
+++ b/electron-app/src/renderer/repositories/clusterRepository.ts
@@ -2,13 +2,14 @@ import { injectable, singleton } from 'tsyringe'
 import { KubeconfigClient } from '../protos/Kubeconfig_serviceServiceClientPb'
 import { GetAvailableClustersRes, RegisterClusterReq } from '../protos/kubeconfig_service_pb'
 import { CommonReq, CommonRes } from '../protos/common_pb'
+import { getDefaultMetadata } from './grpcMetadata'
 
 @singleton()
 export default class ClusterRepository {
   constructor(private readonly client: KubeconfigClient) {}
 
   async GetAvailableClusters(): Promise<GetAvailableClustersRes> {
-    return this.client.getAvailableClusters(new CommonReq(), null)
+    return this.client.getAvailableClusters(new CommonReq(), getDefaultMetadata())
   }
 
   async RegisterCluster(clusterName: string, accountId: string): Promise<CommonRes> {
@@ -17,10 +18,10 @@ export default class ClusterRepository {
     req.setClustername(clusterName)
     req.setAccountid(accountId)
 
-    return this.client.registerCluster(req, null)
+    return this.client.registerCluster(req, getDefaultMetadata())
   }
 
   async SyncAvailableClusters(): Promise<CommonRes> {
-    return this.client.syncAvailableClusters(new CommonReq(), null)
+    return this.client.syncAvailableClusters(new CommonReq(), getDefaultMetadata())
   }
 }

--- a/electron-app/src/renderer/repositories/credResolverRepository.ts
+++ b/electron-app/src/renderer/repositories/credResolverRepository.ts
@@ -8,6 +8,7 @@ import {
   CredResolverConfig,
   DeleteCredResolverReq,
 } from '../protos/kubeconfig_service_pb'
+import { getDefaultMetadata } from './grpcMetadata'
 
 type Req = Pick<CredResolverConfig.AsObject, 'accountid' | 'infravendor'>
 
@@ -18,11 +19,11 @@ export default class CredResolverRepository {
   constructor(private readonly client: KubeconfigClient) {}
 
   async SyncAvailableCredResolvers(): Promise<CommonRes> {
-    return this.client.syncAvailableCredResolvers(new CommonReq(), null)
+    return this.client.syncAvailableCredResolvers(new CommonReq(), getDefaultMetadata())
   }
 
   async getCredResolvers() {
-    return this.client.getAvailableCredResolvers(new CommonReq(), null)
+    return this.client.getAvailableCredResolvers(new CommonReq(), getDefaultMetadata())
   }
 
   // do I have to make this function overload?? WHY???

--- a/electron-app/src/renderer/repositories/credResolverRepository.ts
+++ b/electron-app/src/renderer/repositories/credResolverRepository.ts
@@ -9,8 +9,7 @@ import {
   DeleteCredResolverReq,
 } from '../protos/kubeconfig_service_pb'
 import { getDefaultMetadata } from './grpcMetadata'
-
-type Req = Pick<CredResolverConfig.AsObject, 'accountid' | 'infravendor'>
+import { createErrorResponse } from './error'
 
 export type OtherCredResolverRegisterReq = Omit<CredentialResolverKind, CredentialResolverKind.PROFILE>
 
@@ -19,7 +18,11 @@ export default class CredResolverRepository {
   constructor(private readonly client: KubeconfigClient) {}
 
   async SyncAvailableCredResolvers(): Promise<CommonRes> {
-    return this.client.syncAvailableCredResolvers(new CommonReq(), getDefaultMetadata())
+    try {
+      return await this.client.syncAvailableCredResolvers(new CommonReq(), getDefaultMetadata())
+    } catch (e) {
+      return createErrorResponse(e)
+    }
   }
 
   async getCredResolvers() {
@@ -44,13 +47,21 @@ export default class CredResolverRepository {
       resolverAttrMap.set(key, value)
     }
 
-    return this.client.setCredResolver(req, null)
+    try {
+      return await this.client.setCredResolver(req, getDefaultMetadata())
+    } catch (e) {
+      return createErrorResponse(e)
+    }
   }
 
-  async deleteCredResolver(accountId: string) {
+  async deleteCredResolver(accountId: string): Promise<CommonRes> {
     const req = new DeleteCredResolverReq()
     req.setAccountid(accountId)
 
-    return this.client.deleteCredResolver(req, null)
+    try {
+      return await this.client.deleteCredResolver(req, getDefaultMetadata())
+    } catch (e) {
+      return createErrorResponse(e)
+    }
   }
 }

--- a/electron-app/src/renderer/repositories/error.ts
+++ b/electron-app/src/renderer/repositories/error.ts
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+import { CommonRes, ResultCode } from '../protos/common_pb'
+
+export function createErrorResponse(e: unknown) {
+  const res = new CommonRes()
+
+  res.setStatus(ResultCode.UNKNOWN)
+  res.setMessage(String(e))
+
+  return res
+}

--- a/electron-app/src/renderer/repositories/grpcMetadata.ts
+++ b/electron-app/src/renderer/repositories/grpcMetadata.ts
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+import { Metadata } from 'grpc-web'
+
+// TODO: improve this
+export function getDefaultMetadata(): Metadata {
+  const expires = 10000 // millisecond
+
+  return {
+    deadline: new Date(Date.now() + expires).toString(),
+  }
+}


### PR DESCRIPTION
1. panic 등 모종의 이유로 백엔드 프로세스가 실패할 경우 grpc 에러가 아닌 http 에러를 띄웁니다.
이를 해결하기 위해 각 request 을 try catch 로 묶어 에러 핸들링 로직을 추가합니다.

2. cluster management page 진입 시 무조건 hard reload 를 한 번 수행하도록 변경합니다.