### PR TITLE
Fix: skip err when cli credential files not exist

### DIFF
--- a/backend/pkg/raw_service/aws_service/config_test.go
+++ b/backend/pkg/raw_service/aws_service/config_test.go
@@ -1,0 +1,28 @@
+package aws_service
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetProfilesFromConfig(t *testing.T) {
+	profiles, err := GetProfilesFromConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("Found %d profiles from ~/.aws/config\n", len(profiles))
+	for _, profile := range profiles {
+		fmt.Printf("Profile: %s\n", profile)
+	}
+}
+
+func TestGetProfiles(t *testing.T) {
+	profiles, err := GetProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("Found %d profiles from ~/.aws/config\n", len(profiles))
+	for _, profile := range profiles {
+		fmt.Printf("Profile: %s\n", profile)
+	}
+}

--- a/backend/pkg/raw_service/tencent_service/config.go
+++ b/backend/pkg/raw_service/tencent_service/config.go
@@ -2,6 +2,7 @@ package tencent_service
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -16,7 +17,6 @@ import (
 )
 
 func GetProfiles() ([]string, error) {
-	// TODO: intl 는 .tccli, china 버전은 .tencentcloud 참조함
 	profileNames := make([]string, 0)
 
 	dirPath, err := getCredentialsDirectoryPath()
@@ -25,7 +25,9 @@ func GetProfiles() ([]string, error) {
 	}
 
 	dir, err := os.Stat(dirPath)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
 		return nil, err
 	} else if !dir.IsDir() {
 		return nil, err

--- a/backend/pkg/raw_service/tencent_service/config_test.go
+++ b/backend/pkg/raw_service/tencent_service/config_test.go
@@ -1,0 +1,17 @@
+package tencent_service
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetProfiles(t *testing.T) {
+	profiles, err := GetProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("Found %d profiles from ~/.tccli/*\n", len(profiles))
+	for _, profile := range profiles {
+		fmt.Printf("Profile: %s\n", profile)
+	}
+}


### PR DESCRIPTION
~/.aws/config, ~/.aws/credentials, ~/.tccli/* 파일들이 없을 때 에러가 발생하는것을 수정하고
정상적으로 처리되도록 합니다.